### PR TITLE
Allow overriding QR code URL for public deployments

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,25 @@
 # HTMLEON
 HTML page for Android/IOS/Desktop to display GLB from IFC and use AR if on mobile
+
+## Public URL for QR codes
+
+When the site is hosted publicly, you may want the QR code to point to a
+specific URL rather than the current location. Define a global
+`YOUR_PUBLIC_URL` before loading `script.js`:
+
+```html
+<script>
+  const YOUR_PUBLIC_URL = 'https://example.com/htmleon';
+</script>
+<script src="script.js"></script>
+```
+
+Alternatively, inject the variable from your hosting environment. For
+example, in a simple shell script:
+
+```bash
+export YOUR_PUBLIC_URL="https://example.com/htmleon"
+```
+
+Ensure that `YOUR_PUBLIC_URL` resolves to the public address where the page
+is served so the generated QR code directs to the correct location.

--- a/script.js
+++ b/script.js
@@ -1,11 +1,12 @@
 const isMobile = /Android|iPhone|iPad|iPod/i.test(navigator.userAgent);
 const qrContainer = document.getElementById('qrContainer');
+const qrUrl = YOUR_PUBLIC_URL || window.location.href;
 
 if (!isMobile) {
   qrContainer.style.display = 'flex';
   new QRious({
     element: document.getElementById('qrcode'),
-    value: window.location.href,
+    value: qrUrl,
     size: 180,
     background: 'white',
     foreground: 'black',


### PR DESCRIPTION
## Summary
- allow QR code value to be overridden via `YOUR_PUBLIC_URL`
- document how to configure `YOUR_PUBLIC_URL` when hosting

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af94758d7c83248ba279f397fbe6ff