### PR TITLE
chore: pin script dependencies

### DIFF
--- a/Index.html
+++ b/Index.html
@@ -6,8 +6,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>View in AR – NWSF Model</title>
   <link rel="stylesheet" href="styles.css">
-  <script type="module" src="https://unpkg.com/@google/model-viewer/dist/model-viewer.min.js" defer integrity="sha384-T4vc5AP9W2o3EVVQC6Is5mbKqFE2eysxg1XHwaZLquK0SjtY+4cLHoN3j1mK/MmB" crossorigin="anonymous"></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/qrious/4.0.2/qrious.min.js" defer integrity="sha384-Dr98ddmUw2QkdCarNQ+OL7xLty7cSxgR0T7v1tq4UErS/qLV0132sBYTolRAFuOV" crossorigin="anonymous"></script>
+  <script type="module" src="https://unpkg.com/@google/model-viewer@4.1.0/dist/model-viewer.min.js" defer integrity="sha384-T4vc5AP9W2o3EVVQC6Is5mbKqFE2eysxg1XHwaZLquK0SjtY+4cLHoN3j1mK/MmB" crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/qrious@4.0.2/dist/qrious.min.js" defer integrity="sha384-Dr98ddmUw2QkdCarNQ+OL7xLty7cSxgR0T7v1tq4UErS/qLV0132sBYTolRAFuOV" crossorigin="anonymous"></script>
   <script src="script.js" defer></script>
 </head>
 <body>


### PR DESCRIPTION
## Summary
- pin `@google/model-viewer` and `qrious` script tags to explicit versions with matching SRI hashes

## Testing
- `node test_load.js` *(fails: Error: Failed to launch the browser process! [Invalid file descriptor to ICU data received])*

------
https://chatgpt.com/codex/tasks/task_e_68af943b2b308324abd5615a60fa4142