### PR TITLE
Define public URL constant for QR code

### DIFF
--- a/Index.html
+++ b/Index.html
@@ -8,6 +8,9 @@
   <link rel="stylesheet" href="styles.css">
   <script type="module" src="https://unpkg.com/@google/model-viewer@4.1.0/dist/model-viewer.min.js" defer integrity="sha384-T4vc5AP9W2o3EVVQC6Is5mbKqFE2eysxg1XHwaZLquK0SjtY+4cLHoN3j1mK/MmB" crossorigin="anonymous"></script>
   <script src="https://cdn.jsdelivr.net/npm/qrious@4.0.2/dist/qrious.min.js" defer integrity="sha384-Dr98ddmUw2QkdCarNQ+OL7xLty7cSxgR0T7v1tq4UErS/qLV0132sBYTolRAFuOV" crossorigin="anonymous"></script>
+  <script>
+    const YOUR_PUBLIC_URL = 'https://<your-pages-domain>';
+  </script>
   <script src="script.js" defer></script>
 </head>
 <body>


### PR DESCRIPTION
## Summary
- Define `YOUR_PUBLIC_URL` before loading `script.js` so QR code uses public GitHub Pages URL

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b09bdae95883249d915d030a4fea45