### PR TITLE
Set AR model default scale to 10%

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,6 +23,7 @@
       ar-modes="scene-viewer quick-look webxr"
       camera-controls
       auto-rotate
+      scale="0.1 0.1 0.1"
       shadow-intensity="1"
       environment-image="neutral"
       ios-src="SM Model.usdz"


### PR DESCRIPTION
### Motivation
- Ensure the 3D model opens at a smaller, more manageable size by default when rendered or launched into AR so placement and viewing start at 10% of the original.

### Description
- Added `scale="0.1 0.1 0.1"` to the `<model-viewer>` element in `index.html` so the model loads at 10% size (including AR launch flows supported by `model-viewer`).

### Testing
- Verified the HTML update using `git diff -- index.html` and inspected the file with `nl -ba index.html | sed -n '15,40p'`, confirming the new `scale` attribute is present.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0748628cec8324b8bf27cbb5724cc8)